### PR TITLE
Fix the build in 2016.5 (note: OpenCL support untested).

### DIFF
--- a/scripts/cvwrap/menu.py
+++ b/scripts/cvwrap/menu.py
@@ -1,5 +1,6 @@
 import maya.cmds as cmds
 import maya.mel as mel
+from pymel import versions
 import maya.OpenMayaUI as OpenMayaUI
 import os
 from PySide import QtGui
@@ -17,7 +18,7 @@ def create_menuitems():
     if MENU_ITEMS:
         # Already created
         return
-    if int(cmds.about(v=True)) < 2016:
+    if versions.current() < 201600:
         cmds.warning('cvWrap menus only available in Maya 2016 and higher.')
         return
     for menu in ['mainDeformMenu', 'mainRigDeformationsMenu']:

--- a/src/cvWrapDeformer.cpp
+++ b/src/cvWrapDeformer.cpp
@@ -407,7 +407,7 @@ cl_int EnqueueBuffer(MAutoCLMem& mclMem, size_t bufferSize, void* data) {
                                         bufferSize, data, &err));
 	}	else {
 		// The buffer already exists so just copy the data over.
-		err = clEnqueueWriteBuffer(MOpenCLInfo::getOpenCLCommandQueue(),
+		err = clEnqueueWriteBuffer(MOpenCLInfo::getMayaDefaultOpenCLCommandQueue(),
                                mclMem.get(), CL_TRUE, 0, bufferSize,
                                data, 0, NULL, NULL);
 	}
@@ -523,7 +523,7 @@ MPxGPUDeformer::DeformerStatus CVWrapGPU::evaluate(MDataBlock& block,
 
   // run the kernel
   err = clEnqueueNDRangeKernel(
-    MOpenCLInfo::getOpenCLCommandQueue(),
+    MOpenCLInfo::getMayaDefaultOpenCLCommandQueue(),
     kernel_.get(),
     1,
     NULL,

--- a/src/cvWrapDeformer.h
+++ b/src/cvWrapDeformer.h
@@ -149,6 +149,16 @@ class CVWrapGPUDeformerInfo : public MGPUDeformerRegistrationInfo {
                             const MPlug& plug, MStringArray* messages) {
 		return true;
 	}
+
+	virtual bool validateNodeInGraph(MDataBlock& block, const MEvaluationNode& evaluationNode, const MPlug& plug, MStringArray* messages)
+	{
+		return true;
+	}
+
+	virtual bool validateNodeValues(MDataBlock& block, const MEvaluationNode& evaluationNode, const MPlug& plug, MStringArray* messages)
+	{
+		return true;
+	}
 };
 
 #endif // End Maya 2016


### PR DESCRIPTION
This fixes the build for 2016.5.

OpenCL is untested, since I'm only using it in CPU mode right now.  This is just enough to get things working again.  It'll probably also need more work if you want the build to still work in older versions.  I haven't done that here, but wanted to at least make this available.

The version check change is because the version string is "2016 Extension 2 SP1", so int() fails.  The pymel interface is more reliable than parsing the version string.
