### PR TITLE
For compatibility with wrap, delete the reference mesh when the deformer is deleted

### DIFF
--- a/src/cvWrapDeformer.h
+++ b/src/cvWrapDeformer.h
@@ -1,10 +1,12 @@
 #ifndef CVWRAPDEFORMER_H
 #define CVWRAPDEFORMER_H
 
+#include <maya/MDGModifier.h>
 #include <maya/MFloatArray.h>
 #include <maya/MIntArray.h>
 #include <maya/MMatrix.h> 
 #include <maya/MMatrixArray.h> 
+#include <maya/MMessage.h>
 #include <maya/MPoint.h> 
 #include <maya/MThreadPool.h>
 #include <maya/MPxDeformerNode.h>
@@ -44,6 +46,7 @@ class CVWrap : public MPxDeformerNode {
  public:
   CVWrap();
   virtual ~CVWrap(); 
+  virtual void postConstructor();
   virtual MStatus deform(MDataBlock& data, MItGeometry& iter, const MMatrix& mat,
                          unsigned int mIndex);
   virtual MStatus setDependentsDirty(const MPlug& plugBeingDirtied, MPlugArray& affectedPlugs);
@@ -77,10 +80,12 @@ class CVWrap : public MPxDeformerNode {
   static MTypeId id;
 
 private:
+  static void aboutToDeleteCB(MObject &node, MDGModifier &modifier, void *clientData);
+
   std::map<unsigned int, bool> dirty_;
   std::vector<TaskData> taskData_;  /**< Per geometry evaluation data. */
   std::vector<ThreadData<TaskData>*> threadData_;
-
+  MCallbackId onDeleteCallbackId;
 };
 
 


### PR DESCRIPTION
This imitates wrap's behavior of deleting the base mesh when the deformer is deleted.  This helps make this a drop-in replacement for wrap in scripts, and helps prevent leftover base meshes from being left behind.
