### PR TITLE
Duplicated Attribute Fix

### DIFF
--- a/src/cvWrapDeformer.cpp
+++ b/src/cvWrapDeformer.cpp
@@ -92,8 +92,6 @@ MStatus CVWrap::initialize() {
   nAttr.setMax(64);
   addAttribute(aNumTasks);
   attributeAffects(aNumTasks, outputGeom);
-
-  MGlobal::executeCommand("makePaintable -attrType multiFloat -sm deformer cvWrap weights");
     
   return MS::kSuccess;
 }

--- a/src/pluginMain.cpp
+++ b/src/pluginMain.cpp
@@ -25,6 +25,8 @@ MStatus initializePlugin(MObject obj) {
     MGlobal::executePythonCommandOnIdle("import cvwrap.menu");
 		MGlobal::executePythonCommandOnIdle("cvwrap.menu.create_menuitems()");
   }
+	
+  MGlobal::executeCommand("makePaintable -attrType multiFloat -sm deformer cvWrap weights");
 
   return status;
 }


### PR DESCRIPTION
When calling the MakePaintable Command inside the initialize function of the node, default attributes are duplicated. Instead calling the MakePaintable Command in the initializePlugin function doesn't show the problem...