### PR TITLE
Updating 2018 and newer Maya versions to use the newer evaluate method

### DIFF
--- a/src/cvWrapDeformer.h
+++ b/src/cvWrapDeformer.h
@@ -100,11 +100,16 @@ class CVWrapGPU : public MPxGPUDeformer {
 	CVWrapGPU();
 	virtual ~CVWrapGPU();
 
-	
+#if MAYA_API_VERSION <= 201700
 	virtual MPxGPUDeformer::DeformerStatus evaluate(MDataBlock& block, const MEvaluationNode&,
                                                   const MPlug& plug, unsigned int numElements,
                                                   const MAutoCLMem, const MAutoCLEvent,
                                                   MAutoCLMem, MAutoCLEvent&);
+#else
+	virtual MPxGPUDeformer::DeformerStatus evaluate(MDataBlock& block, const MEvaluationNode& evaluationNode,
+													const MPlug& plug, const MGPUDeformerData& inputData,
+													MGPUDeformerData& outputData);
+#endif
 	virtual void terminate();
 
 	static MGPUDeformerRegistrationInfo* GetGPUDeformerInfo();


### PR DESCRIPTION
If you try to access the input geometry through the datablock, including the world space matrix, any upstream deformers are computed on the CPU inorder to get a valid data handle. This negates the potential gains from GPU deformers upstream as they will run on both GPU and CPU. Autodesk realized this and beginning in 2018, they created a new "evaluate" member function that has additional world space matrix and inverse matrix in a GPU buffer to go along with the local space points buffer. Using this method no longer requires accessing the inputGeom from the datablock, removing that performance hit. Unfortunately they did not back port it to any earlier Maya versions so it will only benefit 2018 and newer. Also unfortunately they kept the matrices in row major order so you have to transpose them before doing the dot product of a point.

This also requires a slight modification to the kernel and separate out some code depending on which Maya you are compiling. 